### PR TITLE
Configure Redis for production

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -2,6 +2,9 @@
 package db
 
 import (
+	"fmt"
+	"os"
+
 	"github.com/go-redis/redis/v8"
 )
 
@@ -9,7 +12,7 @@ var RDB *redis.Client
 
 func Connect() {
 	rdb := redis.NewClient(&redis.Options{
-		Addr:     "redis:6379",
+		Addr:     fmt.Sprintf("%s:6379", os.Getenv("REDIS_HOST")),
 		Password: "",
 		DB:       0,
 	})

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,8 @@ services:
   api:
     build: .
     command: reflex -r '\.go$$' -s -- sh -c 'go build . && ./earl'
+    environment:
+      - REDIS_HOST=redis
     ports:
       - "8000:8000"
     volumes:

--- a/repositories/url/url.go
+++ b/repositories/url/url.go
@@ -6,7 +6,7 @@ import (
 	"time"
 )
 
-const EXPIRATION = time.Minute * 7200
+const EXPIRATION = time.Minute * 120
 
 var ctx = context.Background()
 


### PR DESCRIPTION
- Change the key lifetime to 5 days
- Use environment variable for the Redis host